### PR TITLE
Adds No Parent option for hierarchical taxonomies

### DIFF
--- a/views/admin/templates/generate-terms-page.php
+++ b/views/admin/templates/generate-terms-page.php
@@ -59,6 +59,7 @@
 				<th scope="row"><label for="parent-term"><?php esc_html_e( 'Parent', 'bulk-term-generator' ); ?></label></th>
 				<td>
 					<?php if ( $is_hierarchical ) : ?>
+						<option value="">No Parent</option>
 						<?php
 						echo wp_kses(
 							$term_select_list,


### PR DESCRIPTION
Adds the missing 'no parent' option for hierarchical taxonomies - otherwise one *has* to choose a parent from existing terms.  Currently, one cannot create new top level terms if a term already exists in a hierarchical taxonomy